### PR TITLE
UniversalFlowTransformer and StackWalker

### DIFF
--- a/deobfuscator-api/src/main/java/uwu/narumi/deobfuscator/api/helper/StackWalker.java
+++ b/deobfuscator-api/src/main/java/uwu/narumi/deobfuscator/api/helper/StackWalker.java
@@ -21,7 +21,7 @@ import java.util.Set;
 public class StackWalker implements Opcodes {
   /**
    * Get the only one possible producer of a {@link SourceValue} that is passed to a method.
-   * The main advantage of this method is that it also follows DUP instructions and variable
+   * The main advantage of this method is that it also follows jumps, DUP instructions and variable
    * references to get to the real producer that will be actually useful in another transformers.
    *
    * <p>

--- a/deobfuscator-api/src/main/java/uwu/narumi/deobfuscator/api/helper/StackWalker.java
+++ b/deobfuscator-api/src/main/java/uwu/narumi/deobfuscator/api/helper/StackWalker.java
@@ -1,0 +1,263 @@
+package uwu.narumi.deobfuscator.api.helper;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+import org.objectweb.asm.tree.analysis.Frame;
+import org.objectweb.asm.tree.analysis.SourceValue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A helper class to walk through the stack and get the only one possible and real producer of a {@link SourceValue}.
+ * See {@link #getOnlyOnePossibleProducer(Map, SourceValue)} for more details.
+ *
+ * @author EpicPlayerA10
+ */
+public class StackWalker implements Opcodes {
+  /**
+   * Get the only one possible producer of a {@link SourceValue} that is passed to a method.
+   * The main advantage of this method is that it also follows DUP instructions and variable
+   * references to get to the real producer that will be actually useful in another transformers.
+   *
+   * <p>
+   * Consider this example of instructions:
+   * <pre>
+   * 1: A:
+   * 2:   ICONST_1
+   * 3:   ISTORE exVar
+   * 4: B:
+   * 5:   ILOAD exVar
+   * 6:   DUP
+   * 7:   IFNE C
+   * 8: C:
+   * 9:   ...
+   * </pre>
+   * When this function is called with instruction in line 6, then it will follow all
+   * instructions (DUP, ILOAD) to get real producer of this instruction in line 6. In this
+   * example, it will return instruction in line 2.
+   *
+   * @param sourceValue The value to get the producer of.
+   * @param frames      The frames required to follow DUPs instructions
+   * @return The producer of the value, or an empty optional if there are multiple producers.
+   */
+  public static Optional<StackValue> getOnlyOnePossibleProducer(Map<AbstractInsnNode, Frame<SourceValue>> frames, SourceValue sourceValue) {
+    Set<AbstractInsnNode> valueToStoreInsns = sourceValue.insns;
+    if (valueToStoreInsns.size() != 1) return Optional.empty();
+
+    AbstractInsnNode insn = valueToStoreInsns.iterator().next();
+
+    // Follow DUP instructions
+    StackValue stackValue = buildStackValue(frames, insn);
+    if (stackValue.possibleValues().size() != 1) return Optional.empty();
+
+    return Optional.of(stackValue);
+  }
+
+  public static StackValue buildStackValue(Map<AbstractInsnNode, Frame<SourceValue>> frames, AbstractInsnNode startInsn) {
+    return buildStackValue(new StackValue.BuilderContext(frames, startInsn));
+  }
+
+  /**
+   * Follows DUP and vars (ILOAD instructions).
+   */
+  private static StackValue buildStackValue(StackValue.BuilderContext builderContext) {
+    if (builderContext.currentInsn().getOpcode() == DUP) {
+      // Follow DUP instructions
+      return followDupInstructions(builderContext);
+    } else if (builderContext.currentInsn().getOpcode() == ILOAD) {
+      // Follow vars references
+      Optional<StackValue> stackValue = followVars(builderContext);
+      if (stackValue.isPresent()) return stackValue.get();
+    }
+
+    return builderContext.build(
+        Set.of(builderContext.currentInsn())
+    );
+  }
+
+  /**
+   * Follows DUP instructions.
+   */
+  private static StackValue followDupInstructions(StackValue.BuilderContext builderContext) {
+    Frame<SourceValue> frame = builderContext.getCurrentFrame();
+
+    // Follow DUP instructions
+    Set<AbstractInsnNode> insns = frame.getStack(frame.getStackSize() - 1).insns;
+
+    // If the DUP instruction is followed by another DUP instruction, follow it
+    if (insns.size() == 1) {
+      AbstractInsnNode firstInsn = insns.iterator().next();
+
+      // We can walk further
+      return buildStackValue(
+          builderContext.currentInsn(firstInsn)
+      );
+    }
+
+    // We have the final stack value! Return it
+    return builderContext.build(insns);
+  }
+
+  /**
+   * Follows vars references (ILOAD instructions).
+   */
+  private static Optional<StackValue> followVars(StackValue.BuilderContext builderContext) {
+    Frame<SourceValue> currentFrame = builderContext.getCurrentFrame();
+
+    // Follow vars (ILOAD instructions)
+    VarInsnNode varInsn = (VarInsnNode) builderContext.currentInsn();
+
+    // Get ISTORE of this variable
+    Optional<StackValue> storeVariableInsn = getOnlyOnePossibleProducer(builderContext.frames(), currentFrame.getLocal(varInsn.var));
+    if (storeVariableInsn.isEmpty()) return Optional.empty();
+
+    // Get value that is passed to ISTORE
+    Frame<SourceValue> storeVarFrame = builderContext.frames().get(storeVariableInsn.get().value());
+    if (storeVarFrame == null) return Optional.empty();
+
+    if (builderContext.variableInit().isPresent()) {
+      throw new IllegalStateException("Multiple ISTORE? They should be reduced by StackWalker#getOnlyOnePossibleProducer");
+    }
+
+    builderContext = builderContext
+        .variableInit(storeVariableInsn);
+
+    SourceValue sourceValue = storeVarFrame.getStack(storeVarFrame.getStackSize() - 1);
+    Optional<StackValue> valueInVarInsn = getOnlyOnePossibleProducer(builderContext.frames(), sourceValue);
+
+    // If var has multiple values, we can't follow it. Return immediately
+    if (valueInVarInsn.isEmpty()) {
+      return Optional.of(builderContext.build(sourceValue.insns));
+    }
+
+    // We can walk further
+    return Optional.of(buildStackValue(
+        builderContext
+            .currentInsn(valueInVarInsn.get().value())
+    ));
+  }
+
+  /**
+   * @param possibleValues All possible values from walking on DUP instructions.
+   *                       Don't use it to remove stack value from instructions list.
+   *
+   * @param startInsn      The starting instruction that was passed to the method.
+   *                       Used to remove reference to this stack value
+   *
+   * @param variableInit   If StackValue was obtained from var then it holds the
+   *                       ISTORE instruction that stores the value of this stack value.
+   */
+  public record StackValue(Set<AbstractInsnNode> possibleValues, AbstractInsnNode startInsn,
+                           Optional<StackValue> variableInit) {
+    public boolean isVariable() {
+      return variableInit.isPresent();
+    }
+
+    public AbstractInsnNode value() {
+      return possibleValues.iterator().next();
+    }
+
+    /**
+     * Remove the stack value from the instructions list. Doesn't remove the variable associated with it.
+     *
+     * @param methodNode The method node to remove the stack value from.
+     */
+    public void remove(MethodNode methodNode) {
+      methodNode.instructions.remove(this.startInsn);
+    }
+
+    /**
+     * Remove the stack value from the instructions list along with its variable init.
+     *
+     * @param methodNode The method node to remove the stack value from.
+     * @param toRemove   The list to add the instructions to remove variable init.
+     */
+    public void removeWithVarInit(MethodNode methodNode, List<AbstractInsnNode> toRemove) {
+      this.remove(methodNode);
+
+      if (this.isVariable()) {
+        // ISTORE
+        if (!toRemove.contains(this.variableInit.get().startInsn())) {
+          toRemove.add(this.variableInit.get().startInsn());
+        }
+        // Stored value
+        if (!toRemove.contains(this.value())) {
+          toRemove.add(this.value());
+        }
+      }
+    }
+
+    public static class BuilderContext {
+      // Unmodifiable
+      private final Map<AbstractInsnNode, Frame<SourceValue>> frames;
+
+      private final AbstractInsnNode startInsn;
+      private final AbstractInsnNode currentInsn;
+      private final Optional<StackValue> variableInit;
+
+      public BuilderContext(Map<AbstractInsnNode, Frame<SourceValue>> frames, AbstractInsnNode startInsn) {
+        this(frames, startInsn, startInsn, Optional.empty());
+      }
+
+      public BuilderContext(
+          Map<AbstractInsnNode, Frame<SourceValue>> frames,
+          AbstractInsnNode startInsn,
+          AbstractInsnNode currentInsn,
+          Optional<StackValue> variableInit
+      ) {
+        this.frames = frames;
+
+        this.startInsn = startInsn;
+        this.currentInsn = currentInsn;
+        this.variableInit = variableInit;
+      }
+
+      public Frame<SourceValue> getCurrentFrame() {
+        return frames.get(currentInsn);
+      }
+
+      public Map<AbstractInsnNode, Frame<SourceValue>> frames() {
+        return frames;
+      }
+
+      public AbstractInsnNode startInsn() {
+        return startInsn;
+      }
+
+      public BuilderContext startInsn(AbstractInsnNode startInsn) {
+        return new BuilderContext(this.frames, startInsn, this.currentInsn, this.variableInit);
+      }
+
+      public AbstractInsnNode currentInsn() {
+        return currentInsn;
+      }
+
+      public BuilderContext currentInsn(AbstractInsnNode currentInsn) {
+        return new BuilderContext(this.frames, this.startInsn, currentInsn, this.variableInit);
+      }
+
+      public Optional<StackValue> variableInit() {
+        return variableInit;
+      }
+
+      public BuilderContext variableInit(Optional<StackValue> variableInit) {
+        return new BuilderContext(this.frames, this.startInsn, this.currentInsn, variableInit);
+      }
+
+      /**
+       * Build the {@link StackValue} with the current context and with given possible values.
+       *
+       * @param possibleValues All possible values of the {@link StackValue}
+       * @return Fresh {@link StackValue} instance.
+       */
+      public StackValue build(Set<AbstractInsnNode> possibleValues) {
+        return new StackValue(possibleValues, this.startInsn, this.variableInit);
+      }
+    }
+  }
+}

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedGeneralFlowTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedGeneralFlowTransformer.java
@@ -1,0 +1,29 @@
+package uwu.narumi.deobfuscator.core.other.composed;
+
+import uwu.narumi.deobfuscator.api.transformer.ComposedTransformer;
+import uwu.narumi.deobfuscator.api.transformer.Transformer;
+import uwu.narumi.deobfuscator.core.other.impl.clean.DeadCodeCleanTransformer;
+import uwu.narumi.deobfuscator.core.other.impl.clean.LineNumberCleanTransformer;
+import uwu.narumi.deobfuscator.core.other.impl.clean.UnUsedLabelCleanTransformer;
+import uwu.narumi.deobfuscator.core.other.impl.pool.InlineLocalVariablesTransformer;
+import uwu.narumi.deobfuscator.core.other.impl.pool.InlineStaticFieldTransformer;
+import uwu.narumi.deobfuscator.core.other.impl.universal.UniversalFlowTransformer;
+
+import java.util.List;
+
+public class ComposedGeneralFlowTransformer extends ComposedTransformer {
+  @Override
+  public List<Transformer> transformers() {
+    return List.of(
+        // Preparation
+        new LineNumberCleanTransformer(),
+        new UnUsedLabelCleanTransformer(),
+        new InlineStaticFieldTransformer(true, true),
+        new InlineLocalVariablesTransformer(),
+
+        //new UniversalNumberTransformer(),
+        new UniversalFlowTransformer(),
+        new DeadCodeCleanTransformer()
+    );
+  }
+}

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/DeadCodeCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/DeadCodeCleanTransformer.java
@@ -1,0 +1,122 @@
+package uwu.narumi.deobfuscator.core.other.impl.clean;
+
+import org.objectweb.asm.NamedOpcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.LookupSwitchInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TableSwitchInsnNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicInterpreter;
+import org.objectweb.asm.tree.analysis.Frame;
+import uwu.narumi.deobfuscator.api.asm.ClassWrapper;
+import uwu.narumi.deobfuscator.api.context.Context;
+import uwu.narumi.deobfuscator.api.transformer.Transformer;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class DeadCodeCleanTransformer extends Transformer {
+  @Override
+  public void transform(ClassWrapper scope, Context context) throws Exception {
+    context.classes(scope).forEach(classWrapper -> classWrapper.methods().forEach(methodNode -> {
+      removeDeadCode(context, classWrapper, methodNode);
+
+      try {
+        new UnUsedLabelCleanTransformer().transform(classWrapper, context);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+
+
+      removeUselessGotoJumps(methodNode);
+    }));
+  }
+
+  // Remove useless GOTO jumps
+  /*
+  A:
+    ...
+    goto B
+  B:
+    ...
+   */
+  private void removeUselessGotoJumps(MethodNode methodNode) {
+    for (AbstractInsnNode insn : methodNode.instructions.toArray()) {
+      if (insn.getOpcode() == GOTO) {
+        JumpInsnNode jumpInsn = (JumpInsnNode) insn;
+        if (jumpInsn.getNext() instanceof LabelNode labelNode && jumpInsn.label == labelNode) {
+
+          // Check if the label is used only by the jump instruction
+          if (!isLabelUsedOnlyByInstructions(methodNode, jumpInsn.label)) continue;
+
+          List<AbstractInsnNode> labelUsedInsns = Arrays.stream(methodNode.instructions.toArray())
+              .filter(newInsn -> checkIfJumpHappens(newInsn, labelNode))
+              .toList();
+
+          boolean labelUsedOnlyOnce = labelUsedInsns.size() == 1;
+
+          if (labelUsedOnlyOnce) {
+            // Remove the goto and the label
+            methodNode.instructions.remove(labelNode);
+            methodNode.instructions.remove(jumpInsn);
+          }
+        }
+      }
+    }
+  }
+
+  private static boolean removeDeadCode(Context context, ClassWrapper classWrapper, MethodNode methodNode) {
+    Analyzer<?> analyzer = new Analyzer<>(new BasicInterpreter());
+    try {
+      analyzer.analyze(classWrapper.name(), methodNode);
+    } catch (AnalyzerException e) {
+      throw new RuntimeException(e);
+    }
+    Frame<?>[] frames = analyzer.getFrames();
+    AbstractInsnNode[] insns = methodNode.instructions.toArray();
+    for (int i = 0; i < frames.length; i++) {
+      AbstractInsnNode insn = insns[i];
+      if (frames[i] == null && insn.getType() != AbstractInsnNode.LABEL) {
+        methodNode.instructions.remove(insn);
+        insns[i] = null;
+      }
+    }
+    return false;
+  }
+
+  private boolean isLabelUsedOnlyByInstructions(MethodNode methodNode, LabelNode labelNode) {
+    if (methodNode.tryCatchBlocks != null) {
+      boolean usedByTryCatchBlock = methodNode.tryCatchBlocks.stream()
+          .anyMatch(tryCatchBlockNode -> tryCatchBlockNode.start == labelNode || tryCatchBlockNode.end == labelNode || tryCatchBlockNode.handler == labelNode);
+
+      if (usedByTryCatchBlock) {
+        return false;
+      }
+    }
+
+    if (methodNode.localVariables != null) {
+      boolean usedByLocalVariable = methodNode.localVariables.stream()
+          .anyMatch(localVariableNode -> localVariableNode.start == labelNode || localVariableNode.end == labelNode);
+
+      if (usedByLocalVariable) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean checkIfJumpHappens(AbstractInsnNode insn, LabelNode labelNode) {
+    if (insn instanceof JumpInsnNode jumpInsn) {
+      return jumpInsn.label == labelNode;
+    } else if (insn instanceof LookupSwitchInsnNode lookupSwitchInsn) {
+      return lookupSwitchInsn.labels.contains(labelNode) || lookupSwitchInsn.dflt == labelNode;
+    } else if (insn instanceof TableSwitchInsnNode tableSwitchInsn) {
+      return tableSwitchInsn.labels.contains(labelNode) || tableSwitchInsn.dflt == labelNode;
+    }
+    return false;
+  }
+}

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/UnUsedLabelCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/UnUsedLabelCleanTransformer.java
@@ -36,10 +36,12 @@ public class UnUsedLabelCleanTransformer extends Transformer {
                       node -> {
                         if (node instanceof JumpInsnNode) {
                           labelNodes.add(((JumpInsnNode) node).label);
-                        } else if (node instanceof LookupSwitchInsnNode) {
-                          labelNodes.addAll(((LookupSwitchInsnNode) node).labels);
-                        } else if (node instanceof TableSwitchInsnNode) {
-                          labelNodes.addAll(((TableSwitchInsnNode) node).labels);
+                        } else if (node instanceof LookupSwitchInsnNode lookupSwitchInsnNode) {
+                          labelNodes.addAll(lookupSwitchInsnNode.labels);
+                          labelNodes.add(lookupSwitchInsnNode.dflt);
+                        } else if (node instanceof TableSwitchInsnNode tableSwitchInsnNode) {
+                          labelNodes.addAll(tableSwitchInsnNode.labels);
+                          labelNodes.add(tableSwitchInsnNode.dflt);
                         } else if (node instanceof LineNumberNode) {
                           labelNodes.add(((LineNumberNode) node).start);
                         }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/pool/InlineLocalVariablesTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/pool/InlineLocalVariablesTransformer.java
@@ -1,0 +1,53 @@
+package uwu.narumi.deobfuscator.core.other.impl.pool;
+
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
+import org.objectweb.asm.tree.analysis.Frame;
+import org.objectweb.asm.tree.analysis.SourceValue;
+import uwu.narumi.deobfuscator.api.asm.ClassWrapper;
+import uwu.narumi.deobfuscator.api.context.Context;
+import uwu.narumi.deobfuscator.api.helper.StackWalker;
+import uwu.narumi.deobfuscator.api.transformer.Transformer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Inlines constant local variables
+ */
+public class InlineLocalVariablesTransformer extends Transformer {
+  @Override
+  public void transform(ClassWrapper scope, Context context) throws Exception {
+    context.classes(scope).forEach(classWrapper -> classWrapper.methods().forEach(methodNode -> {
+      Map<AbstractInsnNode, Frame<SourceValue>> frames = analyzeSource(classWrapper.getClassNode(), methodNode);
+      if (frames == null) return;
+
+      List<AbstractInsnNode> toRemove = new ArrayList<>();
+
+      // Inline static local variables
+      for (AbstractInsnNode insn : methodNode.instructions.toArray()) {
+        if (insn.getOpcode() == ILOAD) {
+          VarInsnNode varInsn = (VarInsnNode) insn;
+
+          Frame<SourceValue> frame = frames.get(insn);
+          if (frame == null) continue;
+
+          // Get value from stack that is passed to ILOAD
+          Optional<StackWalker.StackValue> valueInsn = StackWalker.getOnlyOnePossibleProducer(frames, frame.getLocal(varInsn.var));
+          if (valueInsn.isEmpty()) continue;
+
+          if (valueInsn.get().value().isConstant()) {
+            AbstractInsnNode clone = valueInsn.get().value().clone(null);
+            methodNode.instructions.set(insn, clone);
+            valueInsn.get().removeWithVarInit(methodNode, toRemove);
+          }
+        }
+      }
+
+      // Cleanup
+      toRemove.forEach(methodNode.instructions::remove);
+    }));
+  }
+}

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/UniversalFlowTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/UniversalFlowTransformer.java
@@ -1,0 +1,145 @@
+package uwu.narumi.deobfuscator.core.other.impl.universal;
+
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LdcInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.analysis.Frame;
+import org.objectweb.asm.tree.analysis.SourceValue;
+import uwu.narumi.deobfuscator.api.asm.ClassWrapper;
+import uwu.narumi.deobfuscator.api.context.Context;
+import uwu.narumi.deobfuscator.api.helper.AsmMathHelper;
+import uwu.narumi.deobfuscator.api.helper.StackWalker;
+import uwu.narumi.deobfuscator.api.transformer.Transformer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class UniversalFlowTransformer extends Transformer {
+
+  @Override
+  public void transform(ClassWrapper scope, Context context) throws Exception {
+    context.classes(scope).forEach(classWrapper -> classWrapper.methods().forEach(methodNode -> {
+      simplifyCompareInstructions(classWrapper, methodNode);
+      simplifyJumpInstructions(classWrapper, methodNode);
+    }));
+  }
+
+  // TODO: Incomplete. Move to UniversalNumberTransformer during its rewrite.
+  private void simplifyCompareInstructions(ClassWrapper classWrapper, MethodNode methodNode) {
+    Map<AbstractInsnNode, Frame<SourceValue>> frames = analyzeSource(classWrapper.getClassNode(), methodNode);
+    if (frames == null) return;
+
+    // Simplify 'compare' instructions
+    for (AbstractInsnNode insn : methodNode.instructions) {
+      if (insn.getOpcode() == LCMP) {
+        Frame<SourceValue> frame = frames.get(insn);
+        if (frame == null) continue;
+
+        // Get instructions from stack that are passed to LCMP
+        Optional<StackWalker.StackValue> valueInsn1 = StackWalker.getOnlyOnePossibleProducer(frames, frame.getStack(frame.getStackSize() - 2));
+        Optional<StackWalker.StackValue> valueInsn2 = StackWalker.getOnlyOnePossibleProducer(frames, frame.getStack(frame.getStackSize() - 1));
+        if (valueInsn1.isEmpty() || valueInsn2.isEmpty()) continue;
+
+        if (valueInsn1.get().value() instanceof LdcInsnNode ldcValue1 && valueInsn2.get().value() instanceof LdcInsnNode ldcValue2) {
+          long value1 = (long) ldcValue1.cst;
+          long value2 = (long) ldcValue2.cst;
+          if (value1 > value2) {
+            // Result: 1
+            methodNode.instructions.set(insn, new InsnNode(ICONST_1));
+          } else if (value1 < value2) {
+            // Result: -1
+            methodNode.instructions.set(insn, new InsnNode(ICONST_M1));
+          } else {
+            // Result: 0
+            methodNode.instructions.set(insn, new InsnNode(ICONST_0));
+          }
+          valueInsn1.get().remove(methodNode);
+          valueInsn2.get().remove(methodNode);
+        }
+      }
+    }
+  }
+
+  // TODO: Add LOOKUPSWITCH and TABLESWITCH
+  private void simplifyJumpInstructions(ClassWrapper classWrapper, MethodNode methodNode) {
+    Map<AbstractInsnNode, Frame<SourceValue>> frames = analyzeSource(classWrapper.getClassNode(), methodNode);
+    if (frames == null) return;
+
+    List<AbstractInsnNode> toRemove = new ArrayList<>();
+
+    // Simplify 'jump' instructions
+    for (AbstractInsnNode insn : methodNode.instructions) {
+      if (AsmMathHelper.isOneValueCondition(insn.getOpcode())) {
+        // One-value if statement
+
+        Frame<SourceValue> frame = frames.get(insn);
+        if (frame == null) continue;
+
+        JumpInsnNode jumpInsn = (JumpInsnNode) insn;
+
+        // Get instruction from stack that is passed to if statement
+        Optional<StackWalker.StackValue> value = StackWalker.getOnlyOnePossibleProducer(frames, frame.getStack(frame.getStackSize() - 1));
+        if (value.isEmpty()) continue;
+
+        // Process if statement
+        if (value.get().value().isInteger()) {
+          boolean ifResult = AsmMathHelper.condition(
+              value.get().value().asInteger(), // Value
+              jumpInsn.getOpcode() // Opcode
+          );
+
+          // Correctly transform redundant if statement
+          processRedundantIfStatement(methodNode, jumpInsn, ifResult);
+
+          // Cleanup value
+          value.get().removeWithVarInit(methodNode, toRemove);
+        }
+      } else if (AsmMathHelper.isTwoValuesCondition(insn.getOpcode())) {
+        // Two-value if statements
+
+        Frame<SourceValue> frame = frames.get(insn);
+        if (frame == null) continue;
+
+        JumpInsnNode jumpInsn = (JumpInsnNode) insn;
+
+        // Get instructions from stack that are passed to if statement
+        Optional<StackWalker.StackValue> value1 = StackWalker.getOnlyOnePossibleProducer(frames, frame.getStack(frame.getStackSize() - 2));
+        Optional<StackWalker.StackValue> value2 = StackWalker.getOnlyOnePossibleProducer(frames, frame.getStack(frame.getStackSize() - 1));
+        if (value1.isEmpty() || value2.isEmpty()) continue;
+
+        // Process if statement
+        if (value1.get().value().isInteger() && value2.get().value().isInteger()) {
+          boolean ifResult = AsmMathHelper.condition(
+              value1.get().value().asInteger(), // First value
+              value2.get().value().asInteger(), // Second value
+              jumpInsn.getOpcode() // Opcode
+          );
+
+          // Correctly transform redundant if statement
+          processRedundantIfStatement(methodNode, jumpInsn, ifResult);
+
+          // Cleanup values
+          value1.get().removeWithVarInit(methodNode, toRemove);
+          value2.get().removeWithVarInit(methodNode, toRemove);
+        }
+      }
+    }
+
+    // Cleanup
+    toRemove.forEach(methodNode.instructions::remove);
+  }
+
+  private void processRedundantIfStatement(MethodNode methodNode, JumpInsnNode ifStatement, boolean ifResult) {
+    if (!ifResult) {
+      // Remove unreachable if statement
+      methodNode.instructions.remove(ifStatement);
+    } else {
+      // Replace always reachable if statement with GOTO
+      ifStatement.setOpcode(GOTO);
+    }
+  }
+}

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/UniversalFlowTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/UniversalFlowTransformer.java
@@ -69,8 +69,6 @@ public class UniversalFlowTransformer extends Transformer {
     Map<AbstractInsnNode, Frame<SourceValue>> frames = analyzeSource(classWrapper.getClassNode(), methodNode);
     if (frames == null) return;
 
-    List<AbstractInsnNode> toRemove = new ArrayList<>();
-
     // Simplify 'jump' instructions
     for (AbstractInsnNode insn : methodNode.instructions) {
       if (AsmMathHelper.isOneValueCondition(insn.getOpcode())) {
@@ -96,7 +94,7 @@ public class UniversalFlowTransformer extends Transformer {
           processRedundantIfStatement(methodNode, jumpInsn, ifResult);
 
           // Cleanup value
-          value.get().removeWithVarInit(methodNode, toRemove);
+          value.get().remove(methodNode);
         }
       } else if (AsmMathHelper.isTwoValuesCondition(insn.getOpcode())) {
         // Two-value if statements
@@ -123,14 +121,11 @@ public class UniversalFlowTransformer extends Transformer {
           processRedundantIfStatement(methodNode, jumpInsn, ifResult);
 
           // Cleanup values
-          value1.get().removeWithVarInit(methodNode, toRemove);
-          value2.get().removeWithVarInit(methodNode, toRemove);
+          value1.get().remove(methodNode);
+          value2.get().remove(methodNode);
         }
       }
     }
-
-    // Cleanup
-    toRemove.forEach(methodNode.instructions::remove);
   }
 
   private void processRedundantIfStatement(MethodNode methodNode, JumpInsnNode ifStatement, boolean ifResult) {

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/UniversalNumberTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/UniversalNumberTransformer.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 // TODO: Add some light jump emulation, basically rewrite loop to index loop
 // AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 // TODO: Fucking variables?????
+// TODO: All narumii's problems will be solved by StackWalker. Rewrite it using StackWalker
 public class UniversalNumberTransformer extends Transformer {
 
     private final Set<TriFunction<ClassWrapper, MethodNode, AbstractInsnNode, Boolean>> functions = new LinkedHashSet<>();


### PR DESCRIPTION
# Changes
### New transformers
This PR adds some new transformers such as:
- `UniversalFlowTransformer` (in WIP)
- `InlineLocalVariablesTransformer` 
- `DeadCodeCleanTransformer`

### StackWalker
It also adds great `StackWalker` that everybody waited for. It is useful to get the only one producer of a stack value if exists, while following through jumps, `DUP` instructions and variables references. 
See its javadoc for more details why it is so useful. You can see examples of its usage in `UniversalFlowTransformer` and `InlineLocalVariablesTransformer`

### Other
- In `InlineStaticFieldTransformer` auto remove static fields that were inlined.
- Fix `UnUsedLabelCleanTransformer` missing labels references.