### PR TITLE
Many improvements in running transformers

### DIFF
--- a/deobfuscator-api/src/main/java/uwu/narumi/deobfuscator/api/transformer/Transformer.java
+++ b/deobfuscator-api/src/main/java/uwu/narumi/deobfuscator/api/transformer/Transformer.java
@@ -2,22 +2,90 @@ package uwu.narumi.deobfuscator.api.transformer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Opcodes;
 import uwu.narumi.deobfuscator.api.asm.ClassWrapper;
 import uwu.narumi.deobfuscator.api.context.Context;
+import uwu.narumi.deobfuscator.api.exception.TransformerException;
 import uwu.narumi.deobfuscator.api.helper.AsmHelper;
+
+import java.util.function.Supplier;
 
 public abstract class Transformer extends AsmHelper implements Opcodes {
 
   protected static final Logger LOGGER = LogManager.getLogger(Transformer.class);
 
-  public void transform(Context context) throws Exception {
-    transform(null, context);
+  // Config
+  protected boolean rerunOnChange = false;
+
+  /**
+   * Should the transformer rerun if it changed something
+   */
+  public boolean shouldRerunOnChange() {
+    return rerunOnChange;
   }
 
-  public abstract void transform(ClassWrapper scope, Context context) throws Exception;
+  /**
+   * Do the transformation
+   *
+   * @param scope You can choose the class to scope the transformer or set it to null to transform all classes
+   * @param context The context
+   * @return If the transformation changed something
+   */
+  protected abstract boolean transform(ClassWrapper scope, Context context) throws Exception;
 
   public String name() {
     return this.getClass().getSimpleName();
+  }
+
+  /**
+   * Run the transformer
+   *
+   * @param transformerSupplier The transformer supplier with all configuration ready to go. Required to recreate
+   *                            transformer multiple times with the same configuration. You must pass here new instance.
+   *                            You can't reuse the existing instance.
+   * @param scope You can choose the class to scope the transformer or set it to null to transform all classes
+   * @param context The context
+   */
+  public static boolean transform(Supplier<Transformer> transformerSupplier, @Nullable ClassWrapper scope, Context context) {
+    return transform(transformerSupplier, scope, context, null);
+  }
+
+  private static boolean transform(
+      Supplier<Transformer> transformerSupplier,
+      @Nullable ClassWrapper scope,
+      Context context,
+      @Nullable Transformer oldInstance
+  ) {
+    boolean changed = false;
+
+    Transformer transformer = transformerSupplier.get();
+    if (oldInstance != null && transformer == oldInstance) {
+      throw new IllegalArgumentException("transformerSupplier tried to reuse existing transformer instance. You must pass a new instance of transformer");
+    }
+
+    LOGGER.info("-------------------------------------");
+    try {
+
+      LOGGER.info("Running {} transformer", transformer.name());
+      long start = System.currentTimeMillis();
+
+      // Run the transformer!
+      changed = transformer.transform(scope, context);
+      if (changed && transformer.shouldRerunOnChange()) {
+        LOGGER.info("Changes detected. Rerunning {} transformer", transformer.name());
+        Transformer.transform(transformerSupplier, scope, context, transformer);
+      }
+
+      LOGGER.info("Ended {} transformer in {} ms", transformer.name(), (System.currentTimeMillis() - start));
+    } catch (TransformerException e) {
+      LOGGER.error("! {}: {}", transformer.name(), e.getMessage());
+    } catch (Exception e) {
+      LOGGER.error("Error occurred when transforming {}", transformer.name());
+      LOGGER.debug("Error", e);
+    }
+    LOGGER.info("-------------------------------------\n");
+
+    return changed;
   }
 }

--- a/deobfuscator-impl/src/main/java/uwu/narumi/deobfuscator/Deobfuscator.java
+++ b/deobfuscator-impl/src/main/java/uwu/narumi/deobfuscator/Deobfuscator.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import javax.xml.transform.TransformerException;
@@ -28,7 +29,7 @@ public class Deobfuscator {
 
   private final Context context = new Context();
 
-  private final List<Transformer> transformers = new ArrayList<>();
+  private final List<Supplier<Transformer>> transformers = new ArrayList<>();
   private final Path input;
   private final Path output;
   private final int classReaderFlags;
@@ -112,32 +113,11 @@ public class Deobfuscator {
     LOGGER.info("Loaded input file: {}\n", input);
   }
 
-  public void transform(List<Transformer> transformers) {
-    if (transformers == null || transformers.isEmpty()) return;
+  public void transform(List<Supplier<Transformer>> transformersSuppliers) {
+    if (transformersSuppliers == null || transformersSuppliers.isEmpty()) return;
 
-    transformers.forEach(
-        transformer -> {
-          LOGGER.info("-------------------------------------");
-          try {
-            LOGGER.info("Running {} transformer", transformer.name());
-            long start = System.currentTimeMillis();
-            transformer.transform(null, context);
-            LOGGER.info(
-                "Ended {} transformer in {} ms",
-                transformer.name(),
-                (System.currentTimeMillis() - start));
-          } catch (TransformerException e) {
-            LOGGER.error("! {}: {}", transformer.name(), e.getMessage());
-
-            if (consoleDebug) e.printStackTrace();
-          } catch (Exception e) {
-            LOGGER.error("Error occurred when transforming {}", transformer.name());
-            LOGGER.debug("Error", e);
-
-            if (consoleDebug) e.printStackTrace();
-          }
-          LOGGER.info("-------------------------------------\n");
-        });
+    // Run all transformers!
+    transformersSuppliers.forEach(transformerSupplier -> Transformer.transform(transformerSupplier, null, this.context));
   }
 
   private void saveOutput() {
@@ -216,7 +196,7 @@ public class Deobfuscator {
     private final Set<Path> libraries = new HashSet<>();
     private Path input = Path.of("input.jar");
     private Path output = Path.of("output.jar");
-    private List<Transformer> transformers = List.of();
+    private List<Supplier<Transformer>> transformers = List.of();
 
     private int classReaderFlags = ClassReader.EXPAND_FRAMES;
     private int classWriterFlags = ClassWriter.COMPUTE_MAXS;
@@ -252,7 +232,8 @@ public class Deobfuscator {
       return this;
     }
 
-    public Builder transformers(Transformer... transformers) {
+    @SafeVarargs
+    public final Builder transformers(Supplier<Transformer>... transformers) {
       this.transformers = Arrays.asList(transformers);
       return this;
     }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedAllatoriFastStringTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedAllatoriFastStringTransformer.java
@@ -1,19 +1,15 @@
 package uwu.narumi.deobfuscator.core.other.composed;
 
 import uwu.narumi.deobfuscator.api.transformer.ComposedTransformer;
-import uwu.narumi.deobfuscator.api.transformer.Transformer;
 import uwu.narumi.deobfuscator.core.other.impl.allatori.AllatoriStringTransformer;
 import uwu.narumi.deobfuscator.core.other.impl.universal.UniversalNumberTransformer;
 
-import java.util.Arrays;
-import java.util.List;
-
 public class ComposedAllatoriFastStringTransformer extends ComposedTransformer {
 
-    @Override
-    public List<Transformer> transformers() {
-        return Arrays.asList(
-                new UniversalNumberTransformer(),
-                new AllatoriStringTransformer(false));
+    public ComposedAllatoriFastStringTransformer() {
+        super(
+            UniversalNumberTransformer::new,
+            () -> new AllatoriStringTransformer(false)
+        );
     }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedAllatoriStrongStringTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedAllatoriStrongStringTransformer.java
@@ -10,10 +10,10 @@ import java.util.List;
 
 public class ComposedAllatoriStrongStringTransformer extends ComposedTransformer {
 
-    @Override
-    public List<Transformer> transformers() {
-        return Arrays.asList(
-                new UniversalNumberTransformer(),
-                new AllatoriStringTransformer(true));
+    public ComposedAllatoriStrongStringTransformer() {
+        super(
+            UniversalNumberTransformer::new,
+            () -> new AllatoriStringTransformer(true)
+        );
     }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedGeneralCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedGeneralCleanTransformer.java
@@ -1,26 +1,23 @@
 package uwu.narumi.deobfuscator.core.other.composed;
 
-import java.util.Arrays;
-import java.util.List;
 import uwu.narumi.deobfuscator.api.transformer.ComposedTransformer;
-import uwu.narumi.deobfuscator.api.transformer.Transformer;
 import uwu.narumi.deobfuscator.core.other.impl.clean.*;
 import uwu.narumi.deobfuscator.core.other.impl.universal.StackOperationResolveTransformer;
 import uwu.narumi.deobfuscator.core.other.impl.universal.TryCatchRepairTransformer;
 
 public class ComposedGeneralCleanTransformer extends ComposedTransformer {
 
-  @Override
-  public List<Transformer> transformers() {
-    return Arrays.asList(
-        new AnnotationCleanTransformer(),
-        new ClassDebugInfoCleanTransformer(),
-        new LineNumberCleanTransformer(),
-        new MethodDebugInfoCleanTransformer(),
-        new NopCleanTransformer(),
-        new StackOperationResolveTransformer(),
-        new TryCatchRepairTransformer(),
-        new UnknownAttributeCleanTransformer(),
-        new UnUsedLabelCleanTransformer());
+  public ComposedGeneralCleanTransformer() {
+    super(
+        AnnotationCleanTransformer::new,
+        ClassDebugInfoCleanTransformer::new,
+        LineNumberCleanTransformer::new,
+        MethodDebugInfoCleanTransformer::new,
+        NopCleanTransformer::new,
+        StackOperationResolveTransformer::new,
+        TryCatchRepairTransformer::new,
+        UnknownAttributeCleanTransformer::new,
+        UnUsedLabelCleanTransformer::new
+    );
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedGeneralFlowTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedGeneralFlowTransformer.java
@@ -1,7 +1,6 @@
 package uwu.narumi.deobfuscator.core.other.composed;
 
 import uwu.narumi.deobfuscator.api.transformer.ComposedTransformer;
-import uwu.narumi.deobfuscator.api.transformer.Transformer;
 import uwu.narumi.deobfuscator.core.other.impl.clean.DeadCodeCleanTransformer;
 import uwu.narumi.deobfuscator.core.other.impl.clean.LineNumberCleanTransformer;
 import uwu.narumi.deobfuscator.core.other.impl.clean.UnUsedLabelCleanTransformer;
@@ -9,21 +8,19 @@ import uwu.narumi.deobfuscator.core.other.impl.pool.InlineLocalVariablesTransfor
 import uwu.narumi.deobfuscator.core.other.impl.pool.InlineStaticFieldTransformer;
 import uwu.narumi.deobfuscator.core.other.impl.universal.UniversalFlowTransformer;
 
-import java.util.List;
-
 public class ComposedGeneralFlowTransformer extends ComposedTransformer {
-  @Override
-  public List<Transformer> transformers() {
-    return List.of(
-        // Preparation
-        new LineNumberCleanTransformer(),
-        new UnUsedLabelCleanTransformer(),
-        new InlineStaticFieldTransformer(true, true),
-        new InlineLocalVariablesTransformer(),
 
-        //new UniversalNumberTransformer(),
-        new UniversalFlowTransformer(),
-        new DeadCodeCleanTransformer()
+  public ComposedGeneralFlowTransformer() {
+    super(
+        // Preparation
+        LineNumberCleanTransformer::new,
+        UnUsedLabelCleanTransformer::new,
+        () -> new InlineStaticFieldTransformer(true, true),
+        InlineLocalVariablesTransformer::new,
+
+        //UniversalNumberTransformer::new
+        UniversalFlowTransformer::new,
+        DeadCodeCleanTransformer::new
     );
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedGeneralRepairTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedGeneralRepairTransformer.java
@@ -1,9 +1,6 @@
 package uwu.narumi.deobfuscator.core.other.composed;
 
-import java.util.Arrays;
-import java.util.List;
 import uwu.narumi.deobfuscator.api.transformer.ComposedTransformer;
-import uwu.narumi.deobfuscator.api.transformer.Transformer;
 import uwu.narumi.deobfuscator.core.other.impl.clean.ClassDebugInfoCleanTransformer;
 import uwu.narumi.deobfuscator.core.other.impl.clean.MethodDebugInfoCleanTransformer;
 import uwu.narumi.deobfuscator.core.other.impl.clean.SignatureCleanTransformer;
@@ -14,15 +11,15 @@ import uwu.narumi.deobfuscator.core.other.impl.universal.TryCatchRepairTransform
 
 public class ComposedGeneralRepairTransformer extends ComposedTransformer {
 
-  @Override
-  public List<Transformer> transformers() {
-    return Arrays.asList(
-        new AccessRepairTransformer(),
-        new AnnotationFilterTransformer(),
-        new TryCatchRepairTransformer(),
-        new UnknownAttributeCleanTransformer(),
-        new SignatureCleanTransformer(),
-        new MethodDebugInfoCleanTransformer(),
-        new ClassDebugInfoCleanTransformer());
+  public ComposedGeneralRepairTransformer() {
+    super(
+        AccessRepairTransformer::new,
+        AnnotationFilterTransformer::new,
+        TryCatchRepairTransformer::new,
+        UnknownAttributeCleanTransformer::new,
+        SignatureCleanTransformer::new,
+        MethodDebugInfoCleanTransformer::new,
+        ClassDebugInfoCleanTransformer::new
+    );
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/allatori/AllatoriStringTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/allatori/AllatoriStringTransformer.java
@@ -30,7 +30,7 @@ public class AllatoriStringTransformer extends Transformer {
     /* Written by https://github.com/Lampadina17 | 06/08/2024 */
     /* use UniversalNumberTransformer before this transformer to decrypt keys */
     @Override
-    public void transform(ClassWrapper scope, Context context) throws Exception {
+    protected boolean transform(ClassWrapper scope, Context context) throws Exception {
         context.classes(scope).forEach(classWrapper -> {
             classWrapper.methods().forEach(methodNode -> {
 
@@ -102,6 +102,8 @@ public class AllatoriStringTransformer extends Transformer {
             });
         });
         LOGGER.info("Decrypted {} strings in {} classes", resolved.get(), context.classes().size());
+
+        return resolved.get() > 0;
     }
 
     public class DecryptionMethod {

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/AnnotationCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/AnnotationCleanTransformer.java
@@ -7,7 +7,7 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 public class AnnotationCleanTransformer extends Transformer {
 
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context
         .classes(scope)
         .forEach(
@@ -33,5 +33,8 @@ public class AnnotationCleanTransformer extends Transformer {
                         fieldNode.visibleAnnotations = null;
                       });
             });
+
+    // There is always a change
+    return true;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/ClassDebugInfoCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/ClassDebugInfoCleanTransformer.java
@@ -7,7 +7,7 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 public class ClassDebugInfoCleanTransformer extends Transformer {
 
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context
         .classes(scope)
         .forEach(
@@ -15,5 +15,8 @@ public class ClassDebugInfoCleanTransformer extends Transformer {
               classWrapper.getClassNode().sourceDebug = null;
               classWrapper.getClassNode().sourceFile = null;
             });
+
+    // There is always a change
+    return true;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/JunkClassCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/JunkClassCleanTransformer.java
@@ -7,7 +7,7 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 public class JunkClassCleanTransformer extends Transformer {
 
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     throw new UnsupportedOperationException("TODO");
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/LineNumberCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/LineNumberCleanTransformer.java
@@ -8,14 +8,21 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 
 public class LineNumberCleanTransformer extends Transformer {
 
+  private boolean changed = false;
+
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context.classes(scope).stream()
         .flatMap(classWrapper -> classWrapper.methods().stream())
         .forEach(
             methodNode ->
                 Arrays.stream(methodNode.instructions.toArray())
                     .filter(node -> node instanceof LineNumberNode)
-                    .forEach(methodNode.instructions::remove));
+                    .forEach(node -> {
+                        methodNode.instructions.remove(node);
+                        changed = true;
+                    }));
+
+    return changed;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/MethodDebugInfoCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/MethodDebugInfoCleanTransformer.java
@@ -6,8 +6,10 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 
 public class MethodDebugInfoCleanTransformer extends Transformer {
 
+  private boolean changed = false;
+
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context.classes(scope).stream()
         .flatMap(classWrapper -> classWrapper.methods().stream())
         .forEach(
@@ -15,6 +17,9 @@ public class MethodDebugInfoCleanTransformer extends Transformer {
               methodNode.parameters = null;
               methodNode.localVariables = null;
               methodNode.exceptions = null;
+              changed = true;
             });
+
+    return changed;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/NopCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/NopCleanTransformer.java
@@ -7,14 +7,21 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 
 public class NopCleanTransformer extends Transformer {
 
+  private boolean changed = false;
+
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context.classes(scope).stream()
         .flatMap(classWrapper -> classWrapper.methods().stream())
         .forEach(
             methodNode ->
                 Arrays.stream(methodNode.instructions.toArray())
                     .filter(node -> node.getOpcode() == NOP)
-                    .forEach(methodNode.instructions::remove));
+                    .forEach(node -> {
+                      methodNode.instructions.remove(node);
+                      changed = true;
+                    }));
+
+    return changed;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/SignatureCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/SignatureCleanTransformer.java
@@ -7,7 +7,7 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 public class SignatureCleanTransformer extends Transformer {
 
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context
         .classes(scope)
         .forEach(
@@ -16,5 +16,8 @@ public class SignatureCleanTransformer extends Transformer {
               classWrapper.methods().forEach(methodNode -> methodNode.signature = null);
               classWrapper.fields().forEach(fieldNode -> fieldNode.signature = null);
             });
+
+    // There is always a change
+    return true;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/TryCatchBlockCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/TryCatchBlockCleanTransformer.java
@@ -6,10 +6,17 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 
 public class TryCatchBlockCleanTransformer extends Transformer {
 
+  private boolean changed = false;
+
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context.classes(scope).stream()
         .flatMap(classWrapper -> classWrapper.methods().stream())
-        .forEach(methodNode -> methodNode.tryCatchBlocks = null);
+        .forEach(methodNode -> {
+          methodNode.tryCatchBlocks = null;
+          changed = true;
+        });
+
+    return changed;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/UnUsedLabelCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/UnUsedLabelCleanTransformer.java
@@ -11,8 +11,10 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 
 public class UnUsedLabelCleanTransformer extends Transformer {
 
+  private boolean changed = false;
+
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context.classes(scope).stream()
         .flatMap(classWrapper -> classWrapper.methods().stream())
         .forEach(
@@ -47,11 +49,17 @@ public class UnUsedLabelCleanTransformer extends Transformer {
                         }
                       });
 
+              // Remove label nodes that are not used
               Arrays.stream(methodNode.instructions.toArray())
                   .filter(node -> node instanceof LabelNode)
                   .map(LabelNode.class::cast)
                   .filter(node -> !labelNodes.contains(node))
-                  .forEach(methodNode.instructions::remove);
+                  .forEach(insn -> {
+                    methodNode.instructions.remove(insn);
+                    changed = true;
+                  });
             });
+
+    return changed;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/UnknownAttributeCleanTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/clean/UnknownAttributeCleanTransformer.java
@@ -7,19 +7,23 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 
 public class UnknownAttributeCleanTransformer extends Transformer {
 
+  private boolean changed = false;
+
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context
         .classes(scope)
         .forEach(
             classWrapper -> {
-              classWrapper.getClassNode().attrs.removeIf(Attribute::isUnknown);
+              changed |= classWrapper.getClassNode().attrs.removeIf(Attribute::isUnknown);
               classWrapper
                   .methods()
-                  .forEach(methodNode -> methodNode.attrs.removeIf(Attribute::isUnknown));
+                  .forEach(methodNode -> changed |= methodNode.attrs.removeIf(Attribute::isUnknown));
               classWrapper
                   .fields()
-                  .forEach(fieldNode -> fieldNode.attrs.removeIf(Attribute::isUnknown));
+                  .forEach(fieldNode -> changed |= fieldNode.attrs.removeIf(Attribute::isUnknown));
             });
+
+    return changed;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/exploit/WebExploitRemoveTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/exploit/WebExploitRemoveTransformer.java
@@ -6,14 +6,18 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 
 public class WebExploitRemoveTransformer extends Transformer {
 
+  private boolean changed = false;
+
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
-    context.getClasses().entrySet().removeIf(entry -> entry.getKey().contains("<html>"));
-    context.getFiles().entrySet().removeIf(entry -> entry.getKey().contains("<html>"));
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
+    changed |= context.getClasses().entrySet().removeIf(entry -> entry.getKey().contains("<html>"));
+    changed |= context.getFiles().entrySet().removeIf(entry -> entry.getKey().contains("<html>"));
 
     context.classes().forEach(classWrapper -> {
-      classWrapper.methods().removeIf(methodNode -> methodNode.name.contains("<html>"));
-      classWrapper.fields().removeIf(fieldNode -> fieldNode.name.contains("<html>"));
+      changed |= classWrapper.methods().removeIf(methodNode -> methodNode.name.contains("<html>"));
+      changed |= classWrapper.fields().removeIf(fieldNode -> fieldNode.name.contains("<html>"));
     });
+
+    return changed;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/pool/InlineStaticArrayFieldTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/pool/InlineStaticArrayFieldTransformer.java
@@ -165,7 +165,7 @@ public class InlineStaticArrayFieldTransformer extends Transformer {
   }
 
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context
         .classes(scope)
         .forEach(
@@ -233,6 +233,8 @@ public class InlineStaticArrayFieldTransformer extends Transformer {
             });
 
     LOGGER.info("Inlined {} objects in {} classes", inline.get(), context.classes().size());
+
+    return inline.get() > 0;
   }
 
   private void extractData(ClassWrapper classWrapper, MethodNode methodNode, Context context) {

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/pool/InlineStaticFieldTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/pool/InlineStaticFieldTransformer.java
@@ -72,7 +72,7 @@ public class InlineStaticFieldTransformer extends Transformer {
   }
 
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context
         .classes(scope)
         .forEach(
@@ -149,6 +149,8 @@ public class InlineStaticFieldTransformer extends Transformer {
 
     //        values.clear();
     LOGGER.info("Inlined {} numbers in {} classes", inline.get(), context.classes().size());
+
+    return inline.get() > 0;
   }
 
   private void extractNumbers(MethodNode methodNode, Context context) {

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/AccessRepairTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/AccessRepairTransformer.java
@@ -81,15 +81,20 @@ public class AccessRepairTransformer extends Transformer {
     ACC_SYNTHETIC
   };
 
+  private boolean changed = false;
+
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context
         .classes(scope)
         .forEach(
             classWrapper -> {
               int classAccess = classWrapper.getClassNode().access;
               for (int access : CLASS) {
-                if (isAccess(classAccess, access)) classAccess &= ~access;
+                if (isAccess(classAccess, access)) {
+                  classAccess &= ~access;
+                  changed = true;
+                }
               }
               classWrapper.getClassNode().access = classAccess;
 
@@ -98,15 +103,20 @@ public class AccessRepairTransformer extends Transformer {
                   .forEach(
                       methodNode -> {
                         for (int access : METHOD) {
-                          if (isAccess(methodNode.access, access)) methodNode.access &= ~access;
+                          if (isAccess(methodNode.access, access)) {
+                            methodNode.access &= ~access;
+                            changed = true;
+                          }
                         }
 
                         if (methodNode.parameters != null)
                           methodNode.parameters.forEach(
                               parameterNode -> {
                                 for (int access : PARAMETER) {
-                                  if (isAccess(parameterNode.access, access))
+                                  if (isAccess(parameterNode.access, access)) {
                                     parameterNode.access &= ~access;
+                                    changed = true;
+                                  }
                                 }
                               });
                       });
@@ -116,11 +126,16 @@ public class AccessRepairTransformer extends Transformer {
                   .forEach(
                       fieldNode -> {
                         for (int access : FIELD) {
-                          if (isAccess(fieldNode.access, access)) fieldNode.access &= ~access;
+                          if (isAccess(fieldNode.access, access)) {
+                            fieldNode.access &= ~access;
+                            changed = true;
+                          }
                         }
                       });
 
               // TODO: Module maybe?
             });
+
+    return changed;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/AnnotationFilterTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/AnnotationFilterTransformer.java
@@ -19,37 +19,39 @@ public class AnnotationFilterTransformer extends Transformer {
               || annotationNode.desc.contains("\u0000")
               || annotationNode.desc.contains(" ");
 
+  private boolean changed = false;
+
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context
         .classes(scope)
         .forEach(
             classWrapper -> {
               if (classWrapper.getClassNode().invisibleAnnotations != null)
-                classWrapper
+                changed |= classWrapper
                     .getClassNode()
                     .invisibleAnnotations
                     .removeIf(ANNOTATION_NODE_PREDICATE);
 
               if (classWrapper.getClassNode().visibleAnnotations != null)
-                classWrapper.getClassNode().visibleAnnotations.removeIf(ANNOTATION_NODE_PREDICATE);
+                changed |= classWrapper.getClassNode().visibleAnnotations.removeIf(ANNOTATION_NODE_PREDICATE);
 
               classWrapper
                   .methods()
                   .forEach(
                       methodNode -> {
                         if (methodNode.invisibleAnnotations != null)
-                          methodNode.invisibleAnnotations.removeIf(ANNOTATION_NODE_PREDICATE);
+                          changed |= methodNode.invisibleAnnotations.removeIf(ANNOTATION_NODE_PREDICATE);
 
                         if (methodNode.visibleAnnotations != null)
-                          methodNode.visibleAnnotations.removeIf(ANNOTATION_NODE_PREDICATE);
+                          changed |= methodNode.visibleAnnotations.removeIf(ANNOTATION_NODE_PREDICATE);
 
                         if (methodNode.invisibleParameterAnnotations != null)
                           for (List<AnnotationNode> invisibleParameterAnnotation :
                               methodNode.invisibleParameterAnnotations) {
                             if (invisibleParameterAnnotation == null) continue;
 
-                            invisibleParameterAnnotation.removeIf(ANNOTATION_NODE_PREDICATE);
+                            changed |= invisibleParameterAnnotation.removeIf(ANNOTATION_NODE_PREDICATE);
                           }
 
                         if (methodNode.visibleParameterAnnotations != null)
@@ -57,7 +59,7 @@ public class AnnotationFilterTransformer extends Transformer {
                               methodNode.visibleParameterAnnotations) {
                             if (visibleParameterAnnotation == null) continue;
 
-                            visibleParameterAnnotation.removeIf(ANNOTATION_NODE_PREDICATE);
+                            changed |= visibleParameterAnnotation.removeIf(ANNOTATION_NODE_PREDICATE);
                           }
                       });
 
@@ -66,11 +68,13 @@ public class AnnotationFilterTransformer extends Transformer {
                   .forEach(
                       fieldNode -> {
                         if (fieldNode.invisibleAnnotations != null)
-                          fieldNode.invisibleAnnotations.removeIf(ANNOTATION_NODE_PREDICATE);
+                          changed |= fieldNode.invisibleAnnotations.removeIf(ANNOTATION_NODE_PREDICATE);
 
                         if (fieldNode.visibleAnnotations != null)
-                          fieldNode.visibleAnnotations.removeIf(ANNOTATION_NODE_PREDICATE);
+                          changed |= fieldNode.visibleAnnotations.removeIf(ANNOTATION_NODE_PREDICATE);
                       });
             });
+
+    return changed;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/StackOperationResolveTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/StackOperationResolveTransformer.java
@@ -7,7 +7,7 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 public class StackOperationResolveTransformer extends Transformer {
 
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     throw new UnsupportedOperationException("TODO");
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/TryCatchRepairTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/TryCatchRepairTransformer.java
@@ -8,13 +8,15 @@ import uwu.narumi.deobfuscator.api.transformer.Transformer;
 // TODO: Will probably shit itself
 public class TryCatchRepairTransformer extends Transformer {
 
+  private boolean changed = false;
+
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context.classes(scope).stream()
         .flatMap(classWrapper -> classWrapper.methods().stream())
         .forEach(
             methodNode -> {
-              methodNode.tryCatchBlocks.removeIf(
+              this.changed |= methodNode.tryCatchBlocks.removeIf(
                   tbce -> {
                     if (tbce.start.equals(tbce.end)
                         || tbce.start.equals(tbce.handler)
@@ -40,10 +42,12 @@ public class TryCatchRepairTransformer extends Transformer {
                               <= methodNode.instructions.indexOf(end);
                   });
 
-              methodNode.exceptions.removeIf(
+              this.changed |= methodNode.exceptions.removeIf(
                   exception ->
                       methodNode.tryCatchBlocks.stream()
                           .noneMatch(tbce -> tbce.type.equals(exception)));
             });
+
+    return changed;
   }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/UniversalFlowTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/UniversalFlowTransformer.java
@@ -16,12 +16,16 @@ import java.util.Map;
 
 public class UniversalFlowTransformer extends Transformer {
 
+  private boolean changed = false;
+
   @Override
-  public void transform(ClassWrapper scope, Context context) throws Exception {
+  protected boolean transform(ClassWrapper scope, Context context) throws Exception {
     context.classes(scope).forEach(classWrapper -> classWrapper.methods().forEach(methodNode -> {
       simplifyCompareInstructions(classWrapper, methodNode);
       simplifyJumpInstructions(classWrapper, methodNode);
     }));
+
+    return changed;
   }
 
   // TODO: Incomplete. Move to UniversalNumberTransformer during its rewrite.
@@ -58,6 +62,8 @@ public class UniversalFlowTransformer extends Transformer {
           }
           methodNode.instructions.remove(value1SourceValue.getProducer());
           methodNode.instructions.remove(value2SourceValue.getProducer());
+
+          changed = true;
         }
       }
     }
@@ -96,6 +102,8 @@ public class UniversalFlowTransformer extends Transformer {
 
           // Cleanup value
           methodNode.instructions.remove(sourceValue.getProducer());
+
+          changed = true;
         }
       } else if (AsmMathHelper.isTwoValuesCondition(insn.getOpcode())) {
         // Two-value if statements
@@ -127,6 +135,8 @@ public class UniversalFlowTransformer extends Transformer {
           // Cleanup values
           methodNode.instructions.remove(sourceValue1.getProducer());
           methodNode.instructions.remove(sourceValue2.getProducer());
+
+          changed = true;
         }
       }
     }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/UniversalNumberTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/universal/UniversalNumberTransformer.java
@@ -25,7 +25,7 @@ public class UniversalNumberTransformer extends Transformer {
     private final AtomicInteger resolved = new AtomicInteger();
 
     @Override
-    public void transform(ClassWrapper scope, Context context) throws Exception {
+    protected boolean transform(ClassWrapper scope, Context context) throws Exception {
         context.classes(scope).forEach(classWrapper -> {
             for (MethodNode methodNode : classWrapper.methods()) {
                 boolean modified;
@@ -307,6 +307,8 @@ public class UniversalNumberTransformer extends Transformer {
         });
 
         LOGGER.info("Simplified {} number operations in {} classes", resolved.get(), context.classes().size());
+
+        return resolved.get() > 0;
     }
 
     public void registerFunction(TriFunction<ClassWrapper, MethodNode, AbstractInsnNode, Boolean> function) {

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/zkm/ZelixStringTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/zkm/ZelixStringTransformer.java
@@ -25,7 +25,7 @@ public class ZelixStringTransformer extends Transformer {
 
     /* Written by https://github.com/Lampadina17 | OG 19/07/2024, Rewritten 09/08/2024 */
     @Override
-    public void transform(ClassWrapper scope, Context context) throws Exception {
+    protected boolean transform(ClassWrapper scope, Context context) throws Exception {
         context.classes(scope).forEach(classWrapper -> {
             /* Extract key type 1 from hardcoded xor encryption */
             classWrapper.methods().stream()
@@ -176,6 +176,8 @@ public class ZelixStringTransformer extends Transformer {
                     });
         });
         LOGGER.info("Decrypted {} strings in {} classes", resolved.get(), context.classes().size());
+
+        return resolved.get() > 0;
     }
 
     /* Convert arraylist to array and shift values, when a bug transform into a feature (Key type 2) */


### PR DESCRIPTION
# Changes
### The `rerunOnChange` option
There is a new option in `Transformer` called `rerunOnChange`. Then it is set to `true` then when this transformer makes any changes then it will auto rerun. This even works for `ComposedTransformer`! You can play around with it in a cool ways!

Major changes:
- `Transformer#transform` now returns a `boolean` which indicates that this transformer changed something.
- When passing list of transformers, now you must pass a supplier that will create a new instance of your transformer. This is required for `rerunOnChange` to work as we need to create new instance of transformer with exactly the same configuration and no state.

### Improved `Transformer` logging
Copied transformation handling code from `Deobfuscator#transform` to a new static method `Transformation#transform`. We can now call the same method in `ComposedTransformer`. In this way there will be always logging for any transformers!

Major changes:
- Changed method signature of `Transformer#transform` from `public` to `protected` as we are now using this static method over directly calling the method.

### Other changes
- It is no longer required to extend `ComposedTransformer` to be able to use multiple transformers. You can just write `new ComposedTransformer(...)`