### PR TITLE
Allatori deobfuscating adaptation for [ Diobfuscator ]

### DIFF
--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedAllatoriTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/composed/ComposedAllatoriTransformer.java
@@ -1,6 +1,7 @@
 package uwu.narumi.deobfuscator.core.other.composed;
 
 import uwu.narumi.deobfuscator.api.transformer.ComposedTransformer;
+import uwu.narumi.deobfuscator.core.other.impl.allatori.AllatoriStringBuilderTransformer;
 import uwu.narumi.deobfuscator.core.other.impl.allatori.AllatoriStringTransformer;
 import uwu.narumi.deobfuscator.core.other.impl.universal.UniversalNumberTransformer;
 
@@ -9,7 +10,9 @@ public class ComposedAllatoriTransformer extends ComposedTransformer {
     public ComposedAllatoriTransformer(boolean strongString) {
         super(
             UniversalNumberTransformer::new,
-            () -> new AllatoriStringTransformer(strongString)
+            () -> new AllatoriStringTransformer(strongString),
+            // OK
+            AllatoriStringBuilderTransformer::new
         );
     }
 }

--- a/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/allatori/AllatoriStringBuilderTransformer.java
+++ b/deobfuscator-transformers/src/main/java/uwu/narumi/deobfuscator/core/other/impl/allatori/AllatoriStringBuilderTransformer.java
@@ -1,0 +1,87 @@
+/*
+             MODIFIED DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                     Version 2, December 2004
+
+  Copyright (C) 2025 d1cku5er
+
+  Everyone is permitted to copy and distribute verbatim or modified
+  copies of this license document, and changing it is allowed as long
+  as the name is changed.
+
+             MODIFIED DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+   0. You just DO WHAT THE FUCK YOU WANT TO.
+
+
+ */
+package uwu.narumi.deobfuscator.core.other.impl.allatori;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.MethodInsnNode;
+import uwu.narumi.deobfuscator.api.transformer.Transformer;
+
+import java.util.Arrays;
+
+/**
+ * <p>Decompiler-friendly transformer, might change something looks like
+ * <pre><code>
+ *   new StringBuilder().insert(0, "d1ck").append("u5er").toString()
+ * </code></pre>
+ * to
+ * <pre><code>
+ *   "d1ck" + "u5er"
+ * </code></pre>
+ * <br>
+ *
+ * <strong>ALERT: Only works with some specified decompilers, might break
+ * the program</strong>
+ *
+ * @author d1cku5er
+ * @apiNote You might need to use InlineConstantValuesTransformer before using this
+ */
+public class AllatoriStringBuilderTransformer extends Transformer {
+  @Override protected void transform () throws Exception {
+    scopedClasses().forEach(cw -> {
+      cw.methods()
+          .forEach(mn -> {
+            /*
+            (POP) org.objectweb.asm.tree.InsnNode@a
+            (POP) org.objectweb.asm.tree.InsnNode@b
+            (ICONST_0) org.objectweb.asm.tree.InsnNode@c
+            (LDC) org.objectweb.asm.tree.LdcInsnNode@d
+            insert(int String)
+            (INVOKEVIRTUAL) org.objectweb.asm.tree.MethodInsnNode@e
+            */
+            Arrays.stream(mn.instructions.toArray())
+                .forEach(ain -> {
+                  if (ain != null) {
+                    if (
+                      // Invoke virtual check
+                        ain.getOpcode() == Opcodes.INVOKEVIRTUAL
+                        // Method call
+                        && ain.isMethodInsn() && ain.asMethodInsn().name.equals("insert")
+                        // int, java.lang.String
+                        && ain.asMethodInsn().desc.equals("(ILjava/lang/String;)Ljava/lang/StringBuilder;")
+                        // iconst zero
+                        && ain.previous().previous().getOpcode() == Opcodes.ICONST_0
+
+                    ) {
+                      mn.instructions.remove(ain.previous().previous());
+                      ((MethodInsnNode) ain).name = "append";
+                      ((MethodInsnNode) ain).desc = "(Ljava/lang/String;)Ljava/lang/StringBuilder;";
+                      markChange();
+                      /*
+                      (POP) org.objectweb.asm.tree.InsnNode@a
+                      (POP) org.objectweb.asm.tree.InsnNode@b
+                      (LDC) org.objectweb.asm.tree.LdcInsnNode@d
+                      append(String)
+                      (INVOKEVIRTUAL) org.objectweb.asm.tree.MethodInsnNode@e
+                      */
+                    }
+                  }
+                });
+          });
+    });
+  }
+}

--- a/testData/results/custom-classes/allatori/9.4/StringBuilderDeobfuscated.java
+++ b/testData/results/custom-classes/allatori/9.4/StringBuilderDeobfuscated.java
@@ -1,0 +1,10 @@
+import java.io.File;
+
+// Procyon
+public class Obfuscate {
+  public static /* synthetic */ void dummy() {
+    System.out.println(/*EL:295*/a.b() + " " + c.d());
+    System.out.println(/*EL:338*/"Usage:");
+    System.out.println(/*EL:580*/"Dummy string!");
+  }
+}

--- a/testData/results/custom-classes/allatori/9.4/StringDeobfuscated.java
+++ b/testData/results/custom-classes/allatori/9.4/StringDeobfuscated.java
@@ -1,0 +1,10 @@
+import java.io.File;
+
+// Procyon
+public class Obfuscate {
+  public static /* synthetic */ void dummy() {
+    System.out.println(/*EL:295*/new StringBuilder().insert(0x3 & 0x4, a.b()).append(" ").append(c.d()).toString());
+    System.out.println(/*EL:338*/"Usage:");
+    System.out.println(/*EL:580*/"Dummy string!");
+  }
+}


### PR DESCRIPTION
**Allatori** has been officially advertised as a **Professional Java Obfuscator since 2006**. Its goal is to offer the most powerful and feature-rich Java obfuscation solution, combining traditional and innovative techniques to protect intellectual property, enhance code security, and stay at the forefront of Java obfuscation technology. .

**Diobfuscator** is a modern java deobfuscator. Currently, Diobfuscator has been used to deobfuscate obfuscated java programs, providing an excellent opportunity to deobfuscate Allatori obfuscated code. However, the current version of Diobfuscator needs to be adapted to handle Allatori obfuscation techniques effectively.

We're submitting the adaptation code to the **Diobfuscator** project through a pull request (PR). The adapted version of Diobfuscator can simplify strings obfuscated by allatori. Creating this PR is a significant step towards enhancing the capabilities of Diobfuscator and making it more effective in handling Allatori obfuscation techniques.
